### PR TITLE
Make proxy and firefox interact like real browser

### DIFF
--- a/usr/lib/firefox/firefox.js
+++ b/usr/lib/firefox/firefox.js
@@ -61,8 +61,7 @@ function FirefoxWindow(url) {
 
 		var proxyFlagsStr = this._baseConvert(this._getProxyFlagsBinary(), 2, 16);
 
-		var proxifiedUrl = this._proxyUrl + '?q='+encodeURIComponent(btoa(url))+'&hl='+encodeURIComponent(proxyFlagsStr);
-
+                var proxifiedUrl = this._proxyUrl + '?q='+(btoa(url))+'&hl=';
 		return proxifiedUrl;
 	};
 


### PR DESCRIPTION
When proxy enabled url are too many encoded then proxy doesn't understand, now we can use proxy and adresse form like real browser.
